### PR TITLE
adding libstdc++

### DIFF
--- a/bfts_processor/Dockerfile
+++ b/bfts_processor/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM pennsieve/base-processor-pandas-test:1-5800e81  as test
 
+RUN apk add --no-cache --update libstdc++
+
 # code: processor
 COPY bfts_processor/bfts_processor /app/bfts_processor
 COPY bfts_processor/run.py         /app/run.py
@@ -20,6 +22,8 @@ ENTRYPOINT [""]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 FROM pennsieve/base-processor-pandas:1-5800e81  as prod
+
+RUN apk add --no-cache --update libstdc++
 
 # code: processor
 COPY bfts_processor/bfts_processor /app/bfts_processor

--- a/channel_writer_processor/Dockerfile
+++ b/channel_writer_processor/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM pennsieve/base-processor-pandas-test:1-5800e81 as test
 
-RUN apk add --no-cache --update postgresql-dev
+RUN apk add --no-cache --update postgresql-dev libstdc++
 
 # install requirements
 COPY timeseries_db/requirements.txt /app/
@@ -29,7 +29,7 @@ ENTRYPOINT [""]
 
 FROM pennsieve/base-processor-pandas:1-5800e81 as prod
 
-RUN apk add --no-cache --update build-base postgresql-dev wget
+RUN apk add --no-cache --update build-base postgresql-dev wget  libstdc++
 
 # Get AWS root cert for securing postgres connections
 RUN mkdir -p /root/.postgresql \

--- a/edf_processor/Dockerfile
+++ b/edf_processor/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM pennsieve/base-processor-pandas-test:1-5800e81 as test
 
+RUN apk add --no-cache --update libstdc++
+
 # install requirements
 COPY edf_processor/requirements.txt /app/
 RUN  pip install --no-cache-dir -r /app/requirements.txt
@@ -25,7 +27,7 @@ ENTRYPOINT [""]
 
 FROM pennsieve/base-processor-pandas:1-5800e81 as prod
 
-RUN apk add --no-cache --update gcc musl-dev
+RUN apk add --no-cache --update gcc musl-dev libstdc++
 
 # install requirements
 COPY edf_processor/requirements.txt /app/

--- a/moberg_processor/Dockerfile
+++ b/moberg_processor/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM pennsieve/base-processor-pandas-test:1-5800e81 as test
 
+RUN apk add --no-cache --update libstdc++
+
 # install requirements
 COPY moberg_processor/requirements.txt    /app/
 RUN  pip install --no-cache-dir -r        /app/requirements.txt
@@ -32,6 +34,8 @@ ENTRYPOINT [""]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 FROM pennsieve/base-processor-pandas:1-5800e81 as prod
+
+RUN apk add --no-cache --update libstdc++
 
 COPY --from=test /usr/local/lib/python2.7/site-packages/Cython     /usr/local/lib/python2.7/site-packages/
 COPY --from=test /usr/local/lib/python2.7/site-packages/cython.py  /usr/local/lib/python2.7/site-packages/

--- a/nev_processor/Dockerfile
+++ b/nev_processor/Dockerfile
@@ -7,6 +7,8 @@ FROM pennsieve/base-processor-pandas-test:6-43b7408 as test-builder
 ARG PENNSIEVE_NEXUS_USER
 ARG PENNSIEVE_NEXUS_PW
 
+RUN apk add --no-cache --update libstdc++
+
 # install requirements
 COPY nev_processor/requirements.txt /app/
 RUN  pip install --no-cache-dir -r /app/requirements.txt
@@ -44,6 +46,8 @@ FROM pennsieve/base-processor-pandas:1-5800e81 as prod-builder
 
 ARG PENNSIEVE_NEXUS_USER
 ARG PENNSIEVE_NEXUS_PW
+
+RUN apk add --no-cache --update libstdc++
 
 # install requirements
 COPY nev_processor/requirements.txt /app/

--- a/nex_processor/Dockerfile
+++ b/nex_processor/Dockerfile
@@ -7,6 +7,8 @@ FROM pennsieve/base-processor-pandas-test:1-5800e81 as test-builder
 ARG PENNSIEVE_NEXUS_USER
 ARG PENNSIEVE_NEXUS_PW
 
+RUN apk add --no-cache --update libstdc++
+
 # install requirements
 COPY nex_processor/requirements.txt /app/
 RUN  pip install --no-cache-dir -r /app/requirements.txt
@@ -41,6 +43,8 @@ FROM pennsieve/base-processor-pandas:1-5800e81 as prod-builder
 
 ARG PENNSIEVE_NEXUS_USER
 ARG PENNSIEVE_NEXUS_PW
+
+RUN apk add --no-cache --update libstdc++
 
 # install requirements
 COPY nex_processor/requirements.txt /app/

--- a/openephys_processor/Dockerfile
+++ b/openephys_processor/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM pennsieve/base-processor-pandas-test:1-5800e81 as test
 
+RUN apk add --no-cache --update libstdc++
+
 # code: processor
 COPY openephys_processor/openephys_processor     /app/openephys_processor
 COPY openephys_processor/run.py                  /app/run.py
@@ -20,6 +22,8 @@ ENTRYPOINT [""]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 FROM pennsieve/base-processor-pandas:1-5800e81 as prod
+
+RUN apk add --no-cache --update libstdc++
 
 # code: processor
 COPY openephys_processor/openephys_processor        /app/openephys_processor

--- a/persyst_processor/Dockerfile
+++ b/persyst_processor/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM pennsieve/base-processor-pandas-test:1-5800e81  as test
 
+RUN apk add --no-cache --update libstdc++
+
 # code: processor
 COPY persyst_processor/persyst_processor /app/persyst_processor
 COPY persyst_processor/run.py            /app/run.py
@@ -20,6 +22,8 @@ ENTRYPOINT [""]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 FROM pennsieve/base-processor-pandas:1-5800e81 as prod
+
+RUN apk add --no-cache --update libstdc++
 
 # code: processor
 COPY persyst_processor/persyst_processor /app/persyst_processor

--- a/spike2_processor/Dockerfile
+++ b/spike2_processor/Dockerfile
@@ -7,6 +7,8 @@ FROM pennsieve/base-processor-pandas-test:1-5800e81 as test-builder
 ARG PENNSIEVE_NEXUS_USER
 ARG PENNSIEVE_NEXUS_PW
 
+RUN apk add --no-cache --update libstdc++
+
 # install requirements
 COPY spike2_processor/requirements.txt /app/
 RUN  pip install --no-cache-dir -r /app/requirements.txt
@@ -42,6 +44,8 @@ FROM pennsieve/base-processor-pandas:1-5800e81 as prod-builder
 
 ARG PENNSIEVE_NEXUS_USER
 ARG PENNSIEVE_NEXUS_PW
+
+RUN apk add --no-cache --update libstdc++
 
 # install requirements
 COPY spike2_processor/requirements.txt /app/

--- a/tdms_processor/Dockerfile
+++ b/tdms_processor/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM pennsieve/base-processor-pandas-test:1-5800e81 as test
 
+RUN apk add --no-cache --update libstdc++
+
 # install requirements
 COPY tdms_processor/requirements.txt /app/
 RUN  pip install --no-cache-dir -r /app/requirements.txt
@@ -24,6 +26,8 @@ ENTRYPOINT [""]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 FROM pennsieve/base-processor-pandas:1-5800e81 as prod
+
+RUN apk add --no-cache --update libstdc++
 
 # install requirements
 COPY tdms_processor/requirements.txt /app/


### PR DESCRIPTION
pandas-based processors are currently failing with "ImportError: Error loading shared library libstdc++.so.6" (see https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Fbatch$252Fjob/log-events/dev-etl-nex-processor-job-use1$252Fdefault$252Fe5ce9e2fb45e42b59e3810c232994b42 for example)
This should take care of it