### PR TITLE
fetch the updated RDS CA bundle

### DIFF
--- a/timeseries_exporter/Dockerfile
+++ b/timeseries_exporter/Dockerfile
@@ -54,9 +54,8 @@ RUN apk add --no-cache --update \
   lapack \
   lapack-dev
 
-# Get AWS root cert for securing postgres connections
-RUN mkdir -p /root/.postgresql \
-  && wget -qO /root/.postgresql/root.crt https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem
+# Get AWS root CA certificate for securing postgres connections with TLS
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /root/.postgresql/root.crt
 
 # install requirements
 COPY timeseries_exporter/requirements.txt /app/


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [8688dguvj](https://app.clickup.com/t/8688dguvj)

Upgrading the CA we pull down to trust when connecting to our PostgreSQL database using `ssl_mode=verify-ca`. The old CA is set to expire in August 2024 so we will need to upgrade our RDS CA. This change allows us to do that without introducing downtime.

## Testing
Built and ran the image locally to ensure the new CA cert bundle was put in the right location.

Tested using the bundle separately:
- locally (from the dev jump box) using the bundled PEM in place of the single expiring certificate.
- with a JDBC connection via the pennsieve-api repo in: https://github.com/Pennsieve/pennsieve-api/pull/287

Assuming this will work with `sqlalchemy` as well.